### PR TITLE
use yii datetime parser (+default date +exception) 

### DIFF
--- a/EDateCompare.php
+++ b/EDateCompare.php
@@ -5,9 +5,10 @@
  *
  * Validator to compare two dates, works similarly to CCompareValidator.
  *
- * @copyright © Digitick <www.digitick.net> 2012
+ * @copyright © Digitick <www.digitick.net> 2012 / Sébastien Monterisi
  * @license GNU Lesser General Public License v3.0
  * @author Ianaré Sévi
+ * @author Sebastien Monterisi <sebastienmonterisi@yahoo.fr>
  */
 class EDateCompare extends CValidator
 {
@@ -120,67 +121,5 @@ class EDateCompare extends CValidator
 		}
 	}
 
-	public function clientValidateAttribute($object, $attribute)
-	{
-		if ($this->compareValue !== null) {
-			$compareTo = $this->compareValue;
-			$compareValue = CJSON::encode($this->compareValue);
-		}
-		else {
-			$compareAttribute = $this->compareAttribute === null ? $attribute . '_repeat' : $this->compareAttribute;
-			$compareValue = "new Date(\$('#" . (CHtml::activeId($object, $compareAttribute)) . "').val().replace(' ', 'T')).getTime()";
-			$compareTo = $object->getAttributeLabel($compareAttribute);
-		}
-
-		$message = $this->message;
-		$jsDate = 'new Date(value.replace(" ", "T")).getTime()';
-
-		switch ($this->operator) {
-			case '=':
-			case '==':
-				if ($message === null)
-					$message = Yii::t('yii', '{attribute} must be repeated exactly.');
-				$condition = "{$jsDate}!={$compareValue}";
-				break;
-			case '!=':
-				if ($message === null)
-					$message = Yii::t('yii', '{attribute} must not be equal to "{compareValue}".');
-				$condition = "{$jsDate}=={$compareValue}";
-				break;
-			case '>':
-				if ($message === null)
-					$message = Yii::t('yii', '{attribute} must be greater than "{compareValue}".');
-				$condition = "{$jsDate}<={$compareValue}";
-				break;
-			case '>=':
-				if ($message === null)
-					$message = Yii::t('yii', '{attribute} must be greater than or equal to "{compareValue}".');
-				$condition = "{$jsDate}<{$compareValue}";
-				break;
-			case '<':
-				if ($message === null)
-					$message = Yii::t('yii', '{attribute} must be less than "{compareValue}".');
-				$condition = "{$jsDate}>={$compareValue}";
-				break;
-			case '<=':
-				if ($message === null)
-					$message = Yii::t('yii', '{attribute} must be less than or equal to "{compareValue}".');
-				$condition = "{$jsDate}>{$compareValue}";
-				break;
-			default:
-				throw new CException(Yii::t('yii', 'Invalid operator "{operator}".', array('{operator}' => $this->operator)));
-		}
-
-		$message = strtr($message, array(
-			'{attribute}' => $object->getAttributeLabel($attribute),
-			'{compareValue}' => $compareTo,
-				));
-
-		return "
-if(" . ($this->allowEmpty ? "$.trim(value)!='' && " : '') . $condition . ") {
-	messages.push(" . CJSON::encode($message) . ");
-}
-";
-	}
 
 }

--- a/EDateCompare.php
+++ b/EDateCompare.php
@@ -61,6 +61,9 @@ class EDateCompare extends CValidator
 			return;
 		}
 
+                if(!$this->dateFormat)
+                    $this->dateFormat = Yii::app()->locale->getDateFormat('short');
+                    
 		if ($this->compareValue !== null) {
 			$compareTo = $compareValue = $this->compareValue;
 		}
@@ -69,16 +72,16 @@ class EDateCompare extends CValidator
 			$compareValue = $object->$compareAttribute;
 			$compareTo = $object->getAttributeLabel($compareAttribute);
 		}
-		$compareDate = DateTime::createFromFormat($this->dateFormat, $compareValue);
-		$date = DateTime::createFromFormat($this->dateFormat, $value);
 
-		// make sure we have two dates
-		if ($date instanceof DateTime && $compareDate instanceof DateTime)
-			$diff = ((integer) $date->diff($compareDate)->format('%r%a%H%I%S')) * -1;
-		else
-			return; // Perhaps not the best way of handling this. Possibly add an error message.
+                $compareDate=CDateTimeParser::parse($compareValue,$this->dateFormat);
+                $date=CDateTimeParser::parse($value,$this->dateFormat);
+                 
+                if( $compareDate === false || $date === false)
+                    throw new CException('Failled parsing date(s). You should validate formats (attribute, compared attribute, compared value, format) prior to compare values.');
 
-		switch ($this->operator) {
+                $diff = $date-$compareDate;
+
+                switch ($this->operator) {
 			case '=':
 			case '==':
 				if ($diff != 0) {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Extract to your extensions folder.
 
 Alternatively, you can check out from GitHub right in your Git enabled project:
 ~~~
-$ git submodule add git@github.com:digitick/yii-date-compare.git extensions/date-compare
+$ git submodule add git@github.com:SebSept/yii-date-compare.git extensions/date-compare
 $ git submodule init
 $ git submodule update
 ~~~
@@ -38,20 +38,21 @@ public function rules()
         ),
         array('end',
             'ext.date-compare.EDateCompare',
-            'compareAttribute' => 'start',
+            'compareValue' => Yii::app()->locale->dateFormatter->format(Yii::app()->locale->getDateFormat('short'), time()+3600),
             'operator' => '>',
-            'message' => 'End date must be after begin date.'
+            'message' => 'End date must be at least one hour after now.'
         ),
     );
 }
 ~~~
 
 ##Limitations
-For now, the only supported format for Javascript validation is ISO format.
 
-The extension doesn't check if a date is correctly formatted (use the built in "date" validator).
+ * No javascript validation (use ajax instead)
+ * The extension doesn't check if a date is correctly formatted (use the built in "date" validator) but throws an exception in that case.
 
 
 ##Resources
- * [GitHub Repo](https://github.com/digitick/yii-date-compare)
- * [Yii Extension Page](http://www.yiiframework.com/extension/date-compare)
+ * [GitHub Repo](https://github.com/SebSept/yii-date-compare)
+ * [Original GitHub Repo](https://github.com/digitick/yii-date-compare)
+ * [Original Yii Extension Page](http://www.yiiframework.com/extension/date-compare)


### PR DESCRIPTION
- use [yii datetime parser](http://www.yiiframework.com/doc/api/1.1/CDateTimeParser#parse-
  detail) instead of [php
  DateTime::createFromFormat](http://php.net/manual/en/datetime.createfromformat.php)
  - default date format changed to `Yii::app()-
    >locale->getDateFormat('short')`
  - CException throw if failled parsing dates (in previous version
    validation succeded!)
